### PR TITLE
Fix Docker build failure in preview deployment workflow

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -4,12 +4,12 @@ EXPOSE 8080
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY ["src/BARQ.API/BARQ.API.csproj", "src/BARQ.API/"]
-COPY ["src/BARQ.Application/BARQ.Application.csproj", "src/BARQ.Application/"]
-COPY ["src/BARQ.Infrastructure/BARQ.Infrastructure.csproj", "src/BARQ.Infrastructure/"]
-COPY ["src/BARQ.Core/BARQ.Core.csproj", "src/BARQ.Core/"]
+COPY ["Backend/src/BARQ.API/BARQ.API.csproj", "src/BARQ.API/"]
+COPY ["Backend/src/BARQ.Application/BARQ.Application.csproj", "src/BARQ.Application/"]
+COPY ["Backend/src/BARQ.Infrastructure/BARQ.Infrastructure.csproj", "src/BARQ.Infrastructure/"]
+COPY ["Backend/src/BARQ.Core/BARQ.Core.csproj", "src/BARQ.Core/"]
 RUN dotnet restore "src/BARQ.API/BARQ.API.csproj"
-COPY . .
+COPY Backend/ .
 WORKDIR "/src/src/BARQ.API"
 RUN dotnet build "BARQ.API.csproj" -c Release -o /app/build
 


### PR DESCRIPTION
# Fix Docker build failure in preview deployment workflow

## Summary

Fixes the Docker build failure that prevented the BARQ v1.0.0 preview deployment from completing. The issue was that the Dockerfile's COPY commands were using incorrect paths relative to the repository root build context used by GitHub Actions.

**Root Cause**: The GitHub Actions workflow uses the repository root (`.`) as the Docker build context, but the Dockerfile was looking for files at paths like `src/BARQ.API/BARQ.API.csproj` when the actual files are at `Backend/src/BARQ.API/BARQ.API.csproj`.

**Error Messages from Failed Workflow**:
```
ERROR: failed to calculate checksum of ref: "/src/BARQ.API/BARQ.API.csproj": not found
ERROR: failed to calculate checksum of ref: "/src/BARQ.Infrastructure/BARQ.Infrastructure.csproj": not found  
ERROR: failed to calculate checksum of ref: "/src/BARQ.Core/BARQ.Core.csproj": not found
```

**Changes Made**:
- Updated all COPY commands in `Backend/Dockerfile` to use `Backend/src/` prefixed paths
- Changed source copy from `COPY . .` to `COPY Backend/ .` to only copy Backend directory contents

## Review & Testing Checklist for Human

- [ ] **Verify build context configuration**: Confirm that GitHub Actions workflows use repository root (`.`) as Docker build context in `.github/workflows/deploy-preview.yml` and `.github/workflows/deploy-prod.yml`
- [ ] **Test Docker build locally**: Run `docker build -t test -f Backend/Dockerfile .` from repository root to verify the build completes successfully  
- [ ] **Check file copying**: Verify that `COPY Backend/ .` copies all necessary Backend files and doesn't miss any required dependencies
- [ ] **Test deployment workflow**: Manually trigger the "Deploy BARQ Preview" workflow again to confirm it passes the Docker build step

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Root["Repository Root<br/>(Build Context)"]
    Backend["Backend/<br/>(Source Files)"]
    Dockerfile["Backend/Dockerfile"]:::major-edit
    WorkflowPreview[".github/workflows/<br/>deploy-preview.yml"]:::context
    WorkflowProd[".github/workflows/<br/>deploy-prod.yml"]:::context
    
    Root --> Backend
    Backend --> Dockerfile
    Backend --> BackendSrc["Backend/src/<br/>(Project Files)"]:::context
    
    WorkflowPreview --> Dockerfile
    WorkflowProd --> Dockerfile
    
    Dockerfile --> DockerBuild["Docker Build<br/>(ghcr.io/alsairy/barq-api)"]
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This fix is **critical for BARQ v1.0.0 deployment** - the preview deployment cannot proceed without it
- Both preview and production deployment workflows are affected since they use the same Dockerfile
- The fix was based on error log analysis rather than local testing due to deployment workflow constraints
- Once merged, the preview deployment should be retriggered to validate the fix before proceeding with production canary rollout

**Link to Devin run**: https://app.devin.ai/sessions/de6b516b2aec407799266a1acabb0420  
**Requested by**: @Alsairy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build by restricting the build context to the Backend directory.
  * Aligned Dockerfile paths to match the Backend folder structure for more reliable restores and builds.
  * No changes to runtime behavior, images, or entrypoint; users should see no functional differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->