### PR TITLE
Fix TypeScript compilation error in Frontend Dockerfile

### DIFF
--- a/Frontend/barq-frontend/Dockerfile
+++ b/Frontend/barq-frontend/Dockerfile
@@ -2,7 +2,6 @@ FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
-RUN npm install --save-dev typescript
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
# Fix TypeScript compilation error in Frontend Dockerfile

## Summary

Removes redundant `RUN npm install --save-dev typescript` step from Frontend Dockerfile that was causing build failures. TypeScript is already listed in `devDependencies` in package.json (version ~5.6.2), so `npm ci` should install it automatically. The previous approach of adding a separate TypeScript install step was causing "sh: tsc: not found" errors during Docker builds in the preview deployment workflow.

## Review & Testing Checklist for Human

- [ ] **Verify Docker build succeeds**: Test that `docker build -t test-fe -f Frontend/barq-frontend/Dockerfile .` completes without "tsc: not found" errors
- [ ] **Confirm TypeScript availability**: Verify that `tsc` command is available in the build container after `npm ci` step
- [ ] **Test preview deployment**: Manually trigger "Deploy BARQ Preview" workflow to ensure it passes the Frontend build step
- [ ] **Check build performance**: Ensure no regression in build time compared to previous successful builds

**Recommended test plan**: Build the Frontend Docker image locally, then trigger the preview deployment workflow to verify end-to-end success.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    dockerfile["Frontend/barq-frontend/Dockerfile"]:::major-edit
    packagejson["Frontend/barq-frontend/package.json"]:::context
    workflow[".github/workflows/deploy-preview.yml"]:::context
    
    packagejson -->|"contains typescript<br/>in devDependencies"| dockerfile
    dockerfile -->|"npm ci installs<br/>all dependencies"| workflow
    workflow -->|"executes Docker build<br/>for frontend"| deployment["Preview Deployment"]:::context

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#F5F5F5
```

### Notes

- This fix is critical for the BARQ v1.0.0 production deployment pipeline
- The redundant TypeScript install step was likely causing package resolution conflicts
- Since TypeScript (~5.6.2) is already in devDependencies, `npm ci` should handle the installation
- **Risk**: If this doesn't work, we may need to investigate Node.js/npm version differences between local and CI environments

**Session**: https://app.devin.ai/sessions/de6b516b2aec407799266a1acabb0420  
**Requested by**: Abdulaziz AlSuayri (@Alsairy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined frontend Docker build by removing an unnecessary TypeScript dev install step in the build stage. The multi-stage build and final Nginx image remain unchanged.
  * Expected benefits: faster, more reliable CI/builds and a slightly smaller image.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->